### PR TITLE
Support cmec configuration json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,81 +1,87 @@
-# Drought_Metrics  
-Including codes about reading, interpolating, masking NetCDF data of GCMs and calculating metrics to evaluate models' performance on droughts.  
+# Drought_Metrics
+Including codes about reading, interpolating, masking NetCDF data of GCMs and calculating metrics to evaluate models' performance on droughts.
 
-## Environment  
-If using conda, an environment can be created using drought_metrics.yml:  
-`conda env create -f drought_metrics.yml`  
+## Environment
+If using conda, an environment can be created using drought_metrics.yml:
+`conda env create -f drought_metrics.yml`
 
-## How to run this package  
-Use git to clone this repository. There are two ways to run the evaluation.  
+## How to run this package
+Use git to clone this repository. The CMEC driver will run the module from this codebase.
 
-### Run with CMEC driver 
-Follow the instructions here to install cmec-driver: https://github.com/cmecmetrics/cmec-driver  
-From the cmec-driver directory:  
-- Create the following directories: "obs", "model", and "output"  
-- Copy your model data to model/ 
-- Copy your observations to obs/
+### CMEC driver
+Follow the instructions here to install cmec-driver: https://github.com/cmecmetrics/cmec-driver
+From the cmec-driver directory:
+- Create the following directories: "obs", "model", and "output"
+- Copy (or link) your model files to model/
+- Copy (or link) your observational file to obs/
 - Register the module:
-  `python cmec-driver.py register <path to Drought Metrics>`
+  `python cmec-driver.py register <path to Drought Metrics repository>`
 - (Optional) Edit settings in config/cmec.json
 - Run the module:
-`python cmec-driver.py run -obs obs/ model/ output Drought_Metrics`  
+`python cmec-driver.py run -obs obs/ model/ output/ Drought_Metrics`
 
-Your results will be written to cmec-driver/output/Drought_Metrics. Open cmec-driver/output/Drought_Metrics/index.html with your browser to view the generated metrics files and plots.  
+For testing, users may use the model files from Drought_Metrics/data/test. The default observations can be downloaded from the source described in the **Observations** section below.
 
-Results will be overwritten the next time cmec-driver is run with the same output path. To save results, either copy the output/Drought_Metrics folder to a new location or provide a unique output folder path when running cmec-driver.  
+Drought Metrics results will be written to cmec-driver/output/Drought_Metrics. Open cmec-driver/output/Drought_Metrics/index.html with your browser to view the generated metrics files and plots.
 
+Results will be overwritten the next time cmec-driver is run with the same output path. To save results, either copy the output/Drought_Metrics folder to a new location or provide a unique output folder when running cmec-driver.
+
+#### Customizations
 The user settings can be modified in cmec-driver/config/cmec.json after the package is registered.
 
+The directory names "obs", "model", and "output" are recommended with cmec-driver but not required. The observations file should be located in the observations folder passed to cmec-driver, and the model files should be located in the model folder passed to cmec-driver.
+
 ### User settings
-The following files and settings can be changed by the user:
-- obs_path: Observation file path (default: '$CMEC_OBS_DATA/precip.V1.0.mon.mean.nc')
+The following files and settings can be changed by the user in cmec.json:
+- obs_file_name: Observation file name (default: 'precip.V1.0.mon.mean.nc')
 - hu_name: Name of evaluation region (default: 'New England Region')
 - shp_path: Watershed boundary file path (default: 'HU/WBDHU2.shp')
 - wgt_path: netcdf file with grid for interpolation (default 'data/weightfile/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc')
-- interpolation: true to interpolate inputs (default true)
+- interpolation: true to interpolate inputs to same grid (default true)
 - pfa: Path to existing principal metrics results (default 'output_principal_metrics_column_defined')
 - run_pfa: Set to true to generate new PFA analysis (default false)
 
-## Data  
+## Data
 
-### Observations  
-This analysis was designed to use the CPC Unified Gauge-Based Analysis of Daily Precipitation over CONUS. This dataset is available from [NOAA PSL](https://psl.noaa.gov/data/gridded/data.unified.daily.conus.html) (download the monthly mean file precip.V1.0.mon.mean.nc). For best results, at least 50 years of data should be used.  
+### Observations
+This analysis was designed to use the CPC Unified Gauge-Based Analysis of Daily Precipitation over CONUS. This dataset is available from [NOAA PSL](https://psl.noaa.gov/data/gridded/data.unified.daily.conus.html) (download the monthly mean file "precip.V1.0.mon.mean.nc"). For best results, at least 50 years of data should be used.
 
 ### Models
 Monthly precipitation output should be in [CF-compliant](https://cfconventions.org/) netCDF files that conform to the standards for the CMIP6 project. Required dimensions are latitude, longitude, time, and precipitation flux. The Drought Metrics package assumes that there will be a single precipitation variable in each file and that its variable name contains the letters "pr".
 
 ### Principal Metrics
-The user has the option to reuse the results of a previous Principal Metrics analysis or to generate new principal metrics. 
+The user has the option to reuse the results of a previous Principal Features Analysis or to generate new principal metrics.
 
-To use the results of an old PFA analysis, set the optional `pfa` key to the path for those PFA results (by default named 'output_principal_metrics_column_defined').  
+To use the results of an old PFA analysis, set the optional `pfa` key to the path for those PFA results (by default named 'output_principal_metrics_column_defined').
+
 By default, cmec_drought_metrics.sh expects the principal metrics file to be placed in the Drought Metrics code folder.
 
 ### Watershed Boundaries
-This analysis requires a shapefile containing watershed boundaries. The boundary features must contain the fields "Name" and "geometry".  
+This analysis requires a shapefile containing watershed boundaries. The boundary features must contain the fields "Name" and "geometry".
 
 The example boundaries provided in Drought_Metrics/HU are for watersheds in the US at the 2-digit level, based on data obtained from the U.S. Geological Survey and the U.S. Department of Agriculture, Natural Resources Conservation Service. More information [here](https://www.usgs.gov/core-science-systems/ngp/national-hydrography/watershed-boundary-dataset?qt-science_support_page_related_con=4#qt-science_support_page_related_con).
 
-## Contents  
-### Scripts  
-evaluation.py: Evaluation class which computes drought metrics.  
-drought_metrics.py: Driver for evaluation.py  
-dm_cmec_outputs.py: Functions for creating CMEC outputs  
-cmec_drought_metrics.sh: CMEC driver script  
+## Contents
+### Scripts
+evaluation.py: Evaluation class which computes drought metrics.
+drought_metrics.py: Driver for evaluation.py
+dm_cmec_outputs.py: Functions for creating CMEC outputs
+cmec_drought_metrics.sh: CMEC driver script
 
-### Settings  
-settings.json: CMEC settings file  
-drought_metrics.yml: Environment file  
+### Settings
+settings.json: CMEC settings file
+drought_metrics.yml: Environment file
 
-### Templates  
-Tempelates of observational data, model data, weightfile used in interpolation, shapefile defining the evaluation regions and plots are provided. More information can be found in settings.json.  
+### Templates
+Tempelates of observational data, model data, weightfile used in interpolation, shapefile defining the evaluation regions and plots are provided. More information can be found in settings.json.
 
 ### Example outputs
 The folder 'example_output' contains the results from running the Drought Metrics code via cmec-driver while reusing existing principal metrics.
 
-## NOTE  
+## NOTE
 
-#### Auspices  
-This work was performed under the auspices of the U.S. Department of Energy by Lawrence Livermore National Laboratory under Contract DE-AC52-07NA27344. Lawrence Livermore National Laboratory is operated by Lawrence Livermore National Security, LLC, for the U.S. Department of Energy, National Nuclear Security Administration under Contract DE-AC52-07NA27344.  
+#### Auspices
+This work was performed under the auspices of the U.S. Department of Energy by Lawrence Livermore National Laboratory under Contract DE-AC52-07NA27344. Lawrence Livermore National Laboratory is operated by Lawrence Livermore National Security, LLC, for the U.S. Department of Energy, National Nuclear Security Administration under Contract DE-AC52-07NA27344.
 
-#### Disclaimer  
-This document was prepared as an account of work sponsored by an agency of the United States government. Neither the United States government nor Lawrence Livermore National Security, LLC, nor any of their employees makes any warranty, expressed or implied, or assumes any legal liability or responsibility for the accuracy, completeness, or usefulness of any information, apparatus, product, or process disclosed, or represents that its use would not infringe privately owned rights. Reference herein to any specific commercial product, process, or service by trade name, trademark, manufacturer, or otherwise does not necessarily constitute or imply its endorsement, recommendation, or favoring by the United States government or Lawrence Livermore National Security, LLC. The views and opinions of authors expressed herein do not necessarily state or reflect those of the United States government or Lawrence Livermore National Security, LLC, and shall not be used for advertising or product endorsement purposes.  
+#### Disclaimer
+This document was prepared as an account of work sponsored by an agency of the United States government. Neither the United States government nor Lawrence Livermore National Security, LLC, nor any of their employees makes any warranty, expressed or implied, or assumes any legal liability or responsibility for the accuracy, completeness, or usefulness of any information, apparatus, product, or process disclosed, or represents that its use would not infringe privately owned rights. Reference herein to any specific commercial product, process, or service by trade name, trademark, manufacturer, or otherwise does not necessarily constitute or imply its endorsement, recommendation, or favoring by the United States government or Lawrence Livermore National Security, LLC. The views and opinions of authors expressed herein do not necessarily state or reflect those of the United States government or Lawrence Livermore National Security, LLC, and shall not be used for advertising or product endorsement purposes.

--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ This analysis requires a shapefile containing watershed boundaries. The boundary
 The example boundaries provided in Drought_Metrics/HU are for watersheds in the US at the 2-digit level, based on data obtained from the U.S. Geological Survey and the U.S. Department of Agriculture, Natural Resources Conservation Service. More information [here](https://www.usgs.gov/core-science-systems/ngp/national-hydrography/watershed-boundary-dataset?qt-science_support_page_related_con=4#qt-science_support_page_related_con).
 
 ## Contents
-### Scripts
-evaluation.py: Evaluation class which computes drought metrics.
-drought_metrics.py: Driver for evaluation.py
-dm_cmec_outputs.py: Functions for creating CMEC outputs
-cmec_drought_metrics.sh: CMEC driver script
+### Scripts. 
+evaluation.py: Evaluation class which computes drought metrics.  
+drought_metrics.py: Driver for evaluation.py.  
+dm_cmec_outputs.py: Functions for creating CMEC outputs.  
+cmec_drought_metrics.sh: CMEC driver script. 
 
 ### Settings
-settings.json: CMEC settings file
-drought_metrics.yml: Environment file
+settings.json: CMEC settings file.  
+drought_metrics.yml: Environment file. 
 
 ### Templates
 Tempelates of observational data, model data, weightfile used in interpolation, shapefile defining the evaluation regions and plots are provided. More information can be found in settings.json.

--- a/README.md
+++ b/README.md
@@ -8,58 +8,47 @@ If using conda, an environment can be created using drought_metrics.yml:
 ## How to run this package  
 Use git to clone this repository. There are two ways to run the evaluation.  
 
-### Run from Drought_Metrics directory  
-`cd` to the cloned Drought_Metrics directory. Use the command line to run drought_metrics.py:  
-`python drought_metrics.py <-options>`  
-
-To see all options (help):  
-`python drought_metrics.py -h`  
-
-### Run with CMEC driver (recommended)  
+### Run with CMEC driver 
 Follow the instructions here to install cmec-driver: https://github.com/cmecmetrics/cmec-driver  
 From the cmec-driver directory:  
 - Create the following directories: "obs", "model", and "output"  
-- Copy your model data to model/Drought_Metrics  
-- Copy your observations and shapefiles to obs/Drought_Metrics  
-- `cd` to \<path to Drought Metrics\>. Change filenames and settings in cmec_drought_metrics.sh as needed.  
-- `cd` back to cmec-driver. Run the following commands:  
-`python src/cmec-driver.py register <path to Drought Metrics>`  
-`python src/cmec-driver.py run -obs obs/Drought_Metrics model/Drought_Metrics output Drought_Metrics`  
+- Copy your model data to model/ 
+- Copy your observations to obs/
+- Register the module:
+  `python cmec-driver.py register <path to Drought Metrics>`
+- (Optional) Edit settings in config/cmec.json
+- Run the module:
+`python cmec-driver.py run -obs obs/ model/ output Drought_Metrics`  
 
 Your results will be written to cmec-driver/output/Drought_Metrics. Open cmec-driver/output/Drought_Metrics/index.html with your browser to view the generated metrics files and plots.  
 
 Results will be overwritten the next time cmec-driver is run with the same output path. To save results, either copy the output/Drought_Metrics folder to a new location or provide a unique output folder path when running cmec-driver.  
 
-### Required flags
-The following flags are always required to run the Drought Metrics package:
-- test_path: Model data directory
-- obs_path: Observation file path
-- hu_name: Name of evaluation region
-- shp_path: Watershed boundary file path
+The user settings can be modified in cmec-driver/config/cmec.json after the package is registered.
 
-### Optional flags
-Use these flags to specify additional files and settings:
-- test_pr: model precipitation variable name (default "pr")
-- obs_pr: observation precipitation variable name (default "pr")
-- wgt_path: netcdf file with grid for interpolation (default '')
-- out_path: output directory path (default '.')
-- interpolation: True to interpolate inputs (default False)
-- pfa: Path to existing principal metrics results (default None)
+### User settings
+The following files and settings can be changed by the user:
+- obs_path: Observation file path (default: '$CMEC_OBS_DATA/precip.V1.0.mon.mean.nc')
+- hu_name: Name of evaluation region (default: 'New England Region')
+- shp_path: Watershed boundary file path (default: 'HU/WBDHU2.shp')
+- wgt_path: netcdf file with grid for interpolation (default 'data/weightfile/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc')
+- interpolation: true to interpolate inputs (default true)
+- pfa: Path to existing principal metrics results (default 'output_principal_metrics_column_defined')
+- run_pfa: Set to true to generate new PFA analysis (default false)
 
 ## Data  
 
 ### Observations  
-This analysis was designed to use the CPC Unified Gauge-Based Analysis of Daily Precipitation over CONUS. This dataset is available from [NOAA PSL](https://psl.noaa.gov/data/gridded/data.unified.daily.conus.html). For best results, at least 50 years of data should be used.  
+This analysis was designed to use the CPC Unified Gauge-Based Analysis of Daily Precipitation over CONUS. This dataset is available from [NOAA PSL](https://psl.noaa.gov/data/gridded/data.unified.daily.conus.html) (download the monthly mean file precip.V1.0.mon.mean.nc). For best results, at least 50 years of data should be used.  
 
 ### Models
-Monthly precipitation output should be in [CF-compliant](https://cfconventions.org/) netCDF files that conform to the standards for the CMIP6 project. Required dimensions are latitude, longitude, time, and precipitation flux "pr". The published analysis uses CMIP6 output.  
+Monthly precipitation output should be in [CF-compliant](https://cfconventions.org/) netCDF files that conform to the standards for the CMIP6 project. Required dimensions are latitude, longitude, time, and precipitation flux. The Drought Metrics package assumes that there will be a single precipitation variable in each file and that its variable name contains the letters "pr".
 
 ### Principal Metrics
 The user has the option to reuse the results of a previous Principal Metrics analysis or to generate new principal metrics. 
 
-To use the results of an old PFA analysis, set the optional `-pfa` flag to the path for those PFA results (by default named 'output_principal_metrics_column_defined').  
-`python drought_metrics.py -pfa path/to/output_principal_metrics_column_defined`  
-By default, cmec_drought_metrics.sh expects the principal metrics file to be placed in the Drought Metrics code folder. However, the user can overwrite this.
+To use the results of an old PFA analysis, set the optional `pfa` key to the path for those PFA results (by default named 'output_principal_metrics_column_defined').  
+By default, cmec_drought_metrics.sh expects the principal metrics file to be placed in the Drought Metrics code folder.
 
 ### Watershed Boundaries
 This analysis requires a shapefile containing watershed boundaries. The boundary features must contain the fields "Name" and "geometry".  

--- a/cmec_drought_metrics.sh
+++ b/cmec_drought_metrics.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # Needed for local MPI issues
-export MPICH_INTERFACE_HOSTNAME=localhost
+# export MPICH_INTERFACE_HOSTNAME=localhost
 
 cd ${CMEC_CODE_DIR}
 echo "Running drought metrics"
-python drought_metrics.py ${CMEC_CONFIG_DIR}/cmec.json >> ${CMEC_WK_DIR}/drought_metrics_log.txt
+python drought_metrics.py >> ${CMEC_WK_DIR}/drought_metrics_log.txt
 
 # Make cmec outputs if drought metrics succeeds
 if [[ $? = 0 ]]; then

--- a/cmec_drought_metrics.sh
+++ b/cmec_drought_metrics.sh
@@ -1,33 +1,20 @@
 #!/bin/bash
 
-# Change file names as needed for region, obs, and shp.
-# See settings.json for more information about input data.
-region="New England Region"
-obspath=${CMEC_OBS_DATA}/precip.V1.0.mon.mean.nc
-shppath=${CMEC_OBS_DATA}/HU/WBDHU2.shp
-testpath=${CMEC_MODEL_DATA}/
-outpath=${CMEC_WK_DIR}/
-logpath=${outpath}/drought_metrics_log.txt
+# Needed for local MPI issues
+export MPICH_INTERFACE_HOSTNAME=localhost
 
-# Optional settings (Add or delete flags from L23 drought_metrics.py command as needed):
-obspr="precip" # -obs_pr
-intrp=True # -interpolation (True/False)
-wgtpath=${CMEC_MODEL_DATA}/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc # -wgt_path
-pfa=${CMEC_CODE_DIR}/output_principal_metrics_column_defined # -pfa (path or None)
-
-cd $CMEC_WK_DIR
+cd ${CMEC_CODE_DIR}
 echo "Running drought metrics"
-echo "region: "$region
-echo "obs path: "$obspath
-echo "model path: "$testpath
-python $CMEC_CODE_DIR/drought_metrics.py -test_path $testpath -obs_path $obspath -hu_name "$region" -shp_path $shppath -out_path $outpath -wgt_path $wgtpath -obs_pr $obspr -interpolation $intrp -pfa $pfa >> $logpath
+python drought_metrics.py ${CMEC_CONFIG_DIR}/cmec.json >> ${CMEC_WK_DIR}/drought_metrics_log.txt
 
 # Make cmec outputs if drought metrics succeeds
 if [[ $? = 0 ]]; then
     echo "Creating CMEC output"
-    python $CMEC_CODE_DIR/dm_cmec_outputs.py -test_path $testpath -obs_path $obspath -log_path $logpath -hu_name "$region" -out_path $outpath
+    python dm_cmec_outputs.py ${CMEC_CONFIG_DIR}/cmec.json
     # Remove regridding files
-    rm ${outpath}/conservative_*.nc
+    if test -f "${CMEC_WK_DIR}/conservative_*.nc"; then
+        rm ${CMEC_WK_DIR}/conservative_*.nc
+    fi
 else
     echo "Failure in drought_metrics.py"
 fi

--- a/dm_cmec_outputs.py
+++ b/dm_cmec_outputs.py
@@ -13,11 +13,13 @@ Parameters:
     out_path : string
         path to output directory
 """
-import argparse
 from datetime import datetime, timezone
 import json
 import pandas as pd
 from pathlib import Path
+import os
+import sys
+import yaml
 
 def get_env():
     import affine
@@ -294,19 +296,21 @@ def make_html(hu_name, out_path='.'):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Get parameters for cmec output files')
-    parser.add_argument('-test_path', help='GCM file directory')
-    parser.add_argument('-obs_path', help='Observational file')
-    parser.add_argument('-log_path', help='Log file')
-    parser.add_argument('-hu_name', help='Evaluation region in shapefile')
-    parser.add_argument('-out_path', help='Output directory')
-    args = parser.parse_args()
+    # Get CMEC environment variables
+    test_path = os.getenv("CMEC_MODEL_DATA")
+    obs_path = os.getenv("CMEC_OBS_DATA")
+    out_path = os.getenv("CMEC_WK_DIR")
+    log_path = os.path.join(out_path,"drought_metrics_log.txt")
 
-    test_path = args.test_path
-    obs_path = args.obs_path
-    log_path = args.log_path
-    hu_name = args.hu_name
-    out_path = args.out_path
+    # Get user settings
+    user_settings_yaml = sys.argv[1]
+    with open(user_settings_yaml) as config_file:
+        user_settings = yaml.safe_load(config_file).get("Drought_Metrics")
+    # Get any environment variables
+    for setting in user_settings:
+        user_settings[setting] = os.path.expandvars(user_settings[setting])
+    # User settings to global variables
+    globals().update(user_settings)
 
     write_output_json(test_path, obs_path, log_path, hu_name, out_path)
     write_cmec_json(hu_name, out_path)

--- a/drought_metrics.py
+++ b/drought_metrics.py
@@ -33,24 +33,24 @@ import os
 import sys
 from evaluation import evaluation
 
+# Set defaults
+interpolation = False
+shp_path = "./HU/WBDHU2.shp"
+wgt_path = "./data/weightfile/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc"
+pfa = "./output_principal_metrics_column_defined"
+
 # Get CMEC environment variables
 test_path = os.getenv("CMEC_MODEL_DATA")
 obs_path = os.getenv("CMEC_OBS_DATA")
 out_path = os.getenv("CMEC_WK_DIR")
 
 # Get user settings
-user_settings_json = sys.argv[1]
+user_settings_json = os.path.expandvars('$CMEC_CONFIG_DIR/cmec.json')
 with open(user_settings_json) as config_file:
     user_settings = json.load(config_file).get("Drought_Metrics")
 # Get any environment variables and check settings type
 for setting in user_settings:
-    if setting in ["hu_name", "obs_path", "shp_path", "wgt_path"]:
-        if not isinstance(user_settings[setting], str):
-            print("Warning: setting '" + setting + "' should be type string.")
-    elif setting == "interpolation":
-        if not isinstance(user_settings[setting], bool):
-            print("Warning: setting 'interpolation' should be type bool.")
-    if (user_settings[setting], str):
+    if isinstance(user_settings[setting], str):
         user_settings[setting] = os.path.expandvars(user_settings[setting])
 # User settings to global variables
 globals().update(user_settings)

--- a/drought_metrics.py
+++ b/drought_metrics.py
@@ -34,26 +34,31 @@ import sys
 from evaluation import evaluation
 
 # Set defaults
-interpolation = False
+hu_name = "New England Region"
+interpolation = True
+run_pfa = False
 shp_path = "./HU/WBDHU2.shp"
 wgt_path = "./data/weightfile/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc"
 pfa = "./output_principal_metrics_column_defined"
 
 # Get CMEC environment variables
 test_path = os.getenv("CMEC_MODEL_DATA")
-obs_path = os.getenv("CMEC_OBS_DATA")
+obs_path = os.path.join(os.getenv("CMEC_OBS_DATA"),"precip.V1.0.mon.mean.nc")
 out_path = os.getenv("CMEC_WK_DIR")
 
-# Get user settings
+# Get user settings from cmec interface
 user_settings_json = os.path.expandvars('$CMEC_CONFIG_DIR/cmec.json')
-with open(user_settings_json) as config_file:
-    user_settings = json.load(config_file).get("Drought_Metrics")
-# Get any environment variables and check settings type
-for setting in user_settings:
-    if isinstance(user_settings[setting], str):
-        user_settings[setting] = os.path.expandvars(user_settings[setting])
-# User settings to global variables
-globals().update(user_settings)
+try:
+    with open(user_settings_json) as config_file:
+        user_settings = json.load(config_file).get("Drought_Metrics")
+    # Get any environment variables and check settings type
+    for setting in user_settings:
+        if isinstance(user_settings[setting], str):
+            user_settings[setting] = os.path.expandvars(user_settings[setting])
+    # User settings to global variables
+    globals().update(user_settings)
+except:
+    print("Could not load settings from " + str(user_settings_json) + ". Using defaults")
 
 # Loop over all files under TEST_PATH and conduct data analysis.
 x = evaluation()
@@ -63,7 +68,7 @@ x.evaluate_multi_model(
 
 # Conduct the PFA to get Principal Metrics within the region defined.
 # The column names of pricipal metrics are saved at 'output_principal_metrics_column_defined'.
-if pfa is None:
+if run_pfa:
     pfa_path = out_path + "/output_principal_metrics_column_defined"
     x.PFA(out_path=out_path, column_name=pfa_path)
 else:

--- a/drought_metrics.py
+++ b/drought_metrics.py
@@ -33,7 +33,7 @@ import os
 import sys
 from evaluation import evaluation
 
-# Set defaults
+# Set defaults based on demo data
 hu_name = "New England Region"
 interpolation = True
 run_pfa = False
@@ -43,7 +43,7 @@ pfa = "./output_principal_metrics_column_defined"
 
 # Get CMEC environment variables
 test_path = os.getenv("CMEC_MODEL_DATA")
-obs_path = os.path.join(os.getenv("CMEC_OBS_DATA"),"precip.V1.0.mon.mean.nc")
+obs_path = os.getenv("CMEC_OBS_DATA")
 out_path = os.getenv("CMEC_WK_DIR")
 
 # Get user settings from cmec interface
@@ -57,8 +57,10 @@ try:
             user_settings[setting] = os.path.expandvars(user_settings[setting])
     # User settings to global variables
     globals().update(user_settings)
-except:
-    print("Could not load settings from " + str(user_settings_json) + ". Using defaults")
+    obs_path = os.path.join(obs_path, obs_file_name)
+except json.decoder.JSONDecodeError:
+    print("*** Could not load settings from " + str(user_settings_json) + ". Using defaults ***\n")
+    obs_path = os.path.join(obs_path, "precip.V1.0.mon.mean.nc")
 
 # Loop over all files under TEST_PATH and conduct data analysis.
 x = evaluation()
@@ -69,9 +71,11 @@ x.evaluate_multi_model(
 # Conduct the PFA to get Principal Metrics within the region defined.
 # The column names of pricipal metrics are saved at 'output_principal_metrics_column_defined'.
 if run_pfa:
+    print("Running Principal Features Analysis")
     pfa_path = out_path + "/output_principal_metrics_column_defined"
     x.PFA(out_path=out_path, column_name=pfa_path)
 else:
+    print("Using principal features from " + str(pfa_path))
     pfa_path = pfa
 
 # Make sure get the name of pricipal metrics defined by PFA firstly.

--- a/drought_metrics.py
+++ b/drought_metrics.py
@@ -44,14 +44,14 @@ with open(user_settings_json) as config_file:
     user_settings = json.load(config_file).get("Drought_Metrics")
 # Get any environment variables and check settings type
 for setting in user_settings:
-    if setting in ["hu_name", "obs_path", "shp_path", "wgt_path", "pfa"]:
+    if setting in ["hu_name", "obs_path", "shp_path", "wgt_path"]:
         if not isinstance(user_settings[setting], str):
             print("Warning: setting '" + setting + "' should be type string.")
-        else:
-            user_settings[setting] = os.path.expandvars(user_settings[setting])
     elif setting == "interpolation":
         if not isinstance(user_settings[setting], bool):
             print("Warning: setting 'interpolation' should be type bool.")
+    if (user_settings[setting], str):
+        user_settings[setting] = os.path.expandvars(user_settings[setting])
 # User settings to global variables
 globals().update(user_settings)
 

--- a/drought_metrics.py
+++ b/drought_metrics.py
@@ -42,9 +42,16 @@ out_path = os.getenv("CMEC_WK_DIR")
 user_settings_json = sys.argv[1]
 with open(user_settings_json) as config_file:
     user_settings = json.load(config_file).get("Drought_Metrics")
-# Get any environment variables
+# Get any environment variables and check settings type
 for setting in user_settings:
-    user_settings[setting] = os.path.expandvars(user_settings[setting])
+    if setting in ["hu_name", "obs_path", "shp_path", "wgt_path", "pfa"]:
+        if not isinstance(user_settings[setting], str):
+            print("Warning: setting '" + setting + "' should be type string.")
+        else:
+            user_settings[setting] = os.path.expandvars(user_settings[setting])
+    elif setting == "interpolation":
+        if not isinstance(user_settings[setting], bool):
+            print("Warning: setting 'interpolation' should be type bool.")
 # User settings to global variables
 globals().update(user_settings)
 

--- a/evaluation.py
+++ b/evaluation.py
@@ -152,9 +152,9 @@ class evaluation():
             raise DroughtMetricsError("Obs precipitation units must be in kg m-2 s-1 or mm/day")
         self.observe = self.observe.sortby(['lat','lon'])
 
-    def read_weightfile(self,weightfile_path,interpolation = False):
+    def read_weightfile(self,weightfile_path,interpolation=False):
         ##read weightfile data (the destination file used in interpolation)
-        # if data are already interpolated, set the interpolation = False to skip the interpolation
+        # if data are already interpolated, set the interpolation=False to skip the interpolation
         if interpolation:
             self.weightfile = xarray.open_dataset(weightfile_path)
             # transfer lon from 0to360 into -180to180
@@ -172,7 +172,7 @@ class evaluation():
         else:
             self.weightfile = np.nan
 
-    def interpolate(self,test,observe,weightfile,interpolation = False,interpolate_type = 'conservative'):
+    def interpolate(self,test,observe,weightfile,interpolation=False,interpolate_type = 'conservative'):
         #or use bilinear by setting interpolate_type = 'bilinear'
         if interpolation:
             # set lat_b and lon_b

--- a/evaluation.py
+++ b/evaluation.py
@@ -95,11 +95,13 @@ class evaluation():
     def read_test_data(self,test_path):
         self.test = xarray.open_dataset(test_path)
         # find precipitation variable
-        for pr_var in self.test.data_vars:
-            if 'pr' in pr_var:
-                self.test['pr'] = self.test[pr_var]
-            else:
-                raise DroughtMetricsError("No precipitation variable found in test data")
+        found = False
+        for nc_var in self.test.data_vars:
+            if 'pr' in nc_var:
+                self.test['pr'] = self.test[nc_var]
+                found = True
+        if not found:
+            raise DroughtMetricsError("No precipitation variable found in test data")
         if self.test.lon.units == 'degrees_east':
             self.test = self.test.assign_coords({"lon": (((self.test.lon + 180) % 360) - 180)})
             print('Transfer longitude units of test data from degrees_east to degrees_west.')
@@ -107,7 +109,7 @@ class evaluation():
             print('Longitude units of test data is already degrees_west.')
 
         if self.test.pr.units == 'kg m-2 s-1':
-            self.test['pr'] = self.test['pr']* 86400
+            self.test['pr'] = self.test['pr'] * 86400
             print('Transfer precipitation units of test data from kg m-2 s-1 to mm/day.')
         elif self.test.pr.units == 'mm/day':
             print('Precipitation units of test data is already mm/day.')
@@ -124,11 +126,13 @@ class evaluation():
     def read_observe_data(self,observe_path):
         self.observe = xarray.open_dataset(observe_path)
         # find precipitation variable
-        for pr_var in self.observe.data_vars:
-            if 'pr' in pr_var:
-                self.observe['pr'] = self.observe[pr_var]
-            else:
-                raise DroughtMetricsError("No precipitation variable found in observations")
+        found = False
+        for nc_var in self.observe.data_vars:
+            if 'pr' in nc_var:
+                self.observe['pr'] = self.observe[nc_var]
+                found = True
+        if not found:
+            raise DroughtMetricsError("No precipitation variable found in observations")
         # transfer lon from 0to360 into -180to180
         if self.observe.lon.units == 'degrees_east':
             self.observe = self.observe.assign_coords(

--- a/settings.json
+++ b/settings.json
@@ -31,5 +31,13 @@
         "weightfile": {
             "description": "netCDF containing destination grid for interpolation"
         }
+    },
+    "default_parameters": {
+        "hu_name": "New England Region",
+        "interpolation": "False",
+        "obs_path": "${CMEC_OBS_DATA}/CPC_monthly_precipitation_to_1_degree.nc",
+        "shp_path": "${CMEC_OBS_DATA}/HU/WBDHU2.shp",
+        "wgt_path": "${CMEC_MODEL_DATA}/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc",
+        "pfa": "${CMEC_CODE_DIR}/output_principal_metrics_column_defined"
     }
 }

--- a/settings.json
+++ b/settings.json
@@ -34,10 +34,6 @@
     },
     "default_parameters": {
         "hu_name": "New England Region",
-        "interpolation": false,
         "obs_path": "${CMEC_OBS_DATA}/CPC_monthly_precipitation_to_1_degree.nc",
-        "shp_path": "${CMEC_CODE_DIR}/HU/WBDHU2.shp",
-        "wgt_path": "${CMEC_CODE_DIR}/data/weightfile/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc",
-        "pfa": "${CMEC_CODE_DIR}/output_principal_metrics_column_defined"
     }
 }

--- a/settings.json
+++ b/settings.json
@@ -34,7 +34,7 @@
     },
     "default_parameters": {
         "hu_name": "New England Region",
-        "interpolation": "False",
+        "interpolation": false,
         "obs_path": "${CMEC_OBS_DATA}/CPC_monthly_precipitation_to_1_degree.nc",
         "shp_path": "${CMEC_CODE_DIR}/HU/WBDHU2.shp",
         "wgt_path": "${CMEC_CODE_DIR}/data/weightfile/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc",

--- a/settings.json
+++ b/settings.json
@@ -34,6 +34,6 @@
     },
     "default_parameters": {
         "hu_name": "New England Region",
-        "obs_path": "${CMEC_OBS_DATA}/CPC_monthly_precipitation_to_1_degree.nc",
+        "obs_path": "${CMEC_OBS_DATA}/CPC_monthly_precipitation_to_1_degree.nc"
     }
 }

--- a/settings.json
+++ b/settings.json
@@ -33,7 +33,6 @@
         }
     },
     "default_parameters": {
-        "hu_name": "New England Region",
-        "obs_path": "${CMEC_OBS_DATA}/CPC_monthly_precipitation_to_1_degree.nc"
+        "hu_name": "New England Region"
     }
 }

--- a/settings.json
+++ b/settings.json
@@ -36,8 +36,8 @@
         "hu_name": "New England Region",
         "interpolation": "False",
         "obs_path": "${CMEC_OBS_DATA}/CPC_monthly_precipitation_to_1_degree.nc",
-        "shp_path": "${CMEC_OBS_DATA}/HU/WBDHU2.shp",
-        "wgt_path": "${CMEC_MODEL_DATA}/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc",
+        "shp_path": "${CMEC_CODE_DIR}/HU/WBDHU2.shp",
+        "wgt_path": "${CMEC_CODE_DIR}/data/weightfile/interpolated_pr_Amon_E3SM-1-1_historical_r1i1p1f1_gr_187001-200912.nc",
         "pfa": "${CMEC_CODE_DIR}/output_principal_metrics_column_defined"
     }
 }


### PR DESCRIPTION
Summary:
This PR makes some big changes. Drought Metrics uses only the cmec.json configuration file to get user settings. The argparse options are removed. 

Usage:
Users should follow the instructions in the README to run this module in cmec-driver.