### PR TITLE
Add try/except to user settings expansion

### DIFF
--- a/dm_cmec_outputs.py
+++ b/dm_cmec_outputs.py
@@ -307,12 +307,15 @@ if __name__ == "__main__":
     user_settings_yaml = sys.argv[1]
     with open(user_settings_yaml) as config_file:
         user_settings = yaml.safe_load(config_file).get("Drought_Metrics")
-    # Get any environment variables
+    # Get any environment variables in paths
     for setting in user_settings:
-        user_settings[setting] = os.path.expandvars(user_settings[setting])
+        try:
+            user_settings[setting] = os.path.expandvars(user_settings[setting])
+        except TypeError:
+            pass
     # User settings to global variables
     globals().update(user_settings)
 
     write_output_json(test_path, obs_path, log_path, hu_name, out_path)
     write_cmec_json(hu_name, out_path)
-    make_html(hu_name, out_path)
+    #make_html(hu_name, out_path)


### PR DESCRIPTION
The os.path.expandvars function can't be used on settings that are not paths (e.g. will fail when operating on "run_pfa: true"). It is enclosed in a try/except statement to catch the TypeError that occurs when non -string or -path settings are encountered.